### PR TITLE
fix(MM-62375): OutOfMemoryError on gif with build updates v2

### DIFF
--- a/frameanimation/build.gradle
+++ b/frameanimation/build.gradle
@@ -4,10 +4,10 @@ plugins {
 android {
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 28
+        targetSdkVersion 33
         versionCode 1
         versionName "1.0"
-        compileSdk 28
+        compileSdk 33
 
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
 
@@ -35,4 +35,3 @@ dependencies {
     androidTestImplementation 'androidx.test.ext:junit:1.1.2'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
 }
-apply from: rootProject.file('scripts/upload.gradle')

--- a/frameanimation/build.gradle
+++ b/frameanimation/build.gradle
@@ -4,10 +4,10 @@ plugins {
 android {
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 33
+        targetSdkVersion 34
         versionCode 1
         versionName "1.0"
-        compileSdk 33
+        compileSdk 35
 
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
 

--- a/frameanimation/build.gradle
+++ b/frameanimation/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 android {
     defaultConfig {
-        minSdkVersion 16
+        minSdkVersion 21
         targetSdkVersion 34
         versionCode 1
         versionName "1.0"

--- a/frameanimation/src/main/java/com/github/penfeizhou/animation/decode/FrameSeqDecoder.java
+++ b/frameanimation/src/main/java/com/github/penfeizhou/animation/decode/FrameSeqDecoder.java
@@ -103,7 +103,7 @@ public abstract class FrameSeqDecoder<R extends Reader, W extends Writer> {
 
     protected Bitmap obtainBitmap(int width, int height) {
         synchronized (cacheBitmapsLock) {
-                        Bitmap ret = null;
+            Bitmap ret = null;
             Iterator<Bitmap> iterator = cacheBitmaps.iterator();
             while (iterator.hasNext()) {
                 int reuseSize = width * height * 4;

--- a/frameanimation/src/main/java/com/github/penfeizhou/animation/decode/FrameSeqDecoder.java
+++ b/frameanimation/src/main/java/com/github/penfeizhou/animation/decode/FrameSeqDecoder.java
@@ -251,29 +251,19 @@ public abstract class FrameSeqDecoder<R extends Reader, W extends Writer> {
 
     private void initCanvasBounds(Rect rect) {
         fullRect = rect;
-        Runtime runtime = Runtime.getRuntime();
-        long freeMemory = runtime.freeMemory();
+        long bufferSize = ((long) rect.width() * rect.height() / ((long) sampleSize * sampleSize) + 1) * 4;
 
-        try {
-            long bufferSize = ((long) rect.width() * rect.height() / ((long) sampleSize * sampleSize) + 1) * 4;
-            
-            if (bufferSize > freeMemory) {
-                Log.e(TAG, String.format(
-                        "Memory status:" +
-                        "\n  Buffer needed: %.2fMB (%,d bytes)" +
-                        "\n  Free memory: %.2fMB (%,d bytes)",
-                        bufferSize / MB, bufferSize,
-                        freeMemory / MB, freeMemory
-                    )
-                );
-                throw new OutOfMemoryError("Required buffer size too large: " + bufferSize);
-            }
-                
+        try {                
             frameBuffer = ByteBuffer.allocate((int)bufferSize);
             if (mWriter == null) {
                 mWriter = getWriter();
             }
         } catch (OutOfMemoryError error) {
+            Log.e(TAG, String.format(
+                    "OutOfMemoryError in FrameSeqDecoder: Buffer needed: %.2fMB (%,d bytes)",
+                    bufferSize / MB, bufferSize
+                )
+            );
             frameBuffer = null;
             fullRect = RECT_EMPTY;
             throw error;

--- a/gif/build.gradle
+++ b/gif/build.gradle
@@ -4,7 +4,7 @@ plugins {
 
 android {
     defaultConfig {
-        minSdkVersion 16
+        minSdkVersion 21
         targetSdkVersion 34
         versionCode 1
         versionName "1.0"

--- a/gif/build.gradle
+++ b/gif/build.gradle
@@ -5,10 +5,10 @@ plugins {
 android {
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 28
+        targetSdkVersion 33
         versionCode 1
         versionName "1.0"
-        compileSdk 28
+        compileSdk 33
 
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
 
@@ -43,10 +43,9 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
 
     implementation 'androidx.appcompat:appcompat:1.2.0'
-    api("com.github.penfeizhou.android.animation:frameanimation:${rootProject.ext.Version}")
+    api project(':frameanimation')
 
     testImplementation 'junit:junit:4.13'
     androidTestImplementation 'androidx.test.ext:junit:1.1.2'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
 }
-apply from: rootProject.file('scripts/upload.gradle')

--- a/gif/build.gradle
+++ b/gif/build.gradle
@@ -5,10 +5,10 @@ plugins {
 android {
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 33
+        targetSdkVersion 34
         versionCode 1
         versionName "1.0"
-        compileSdk 33
+        compileSdk 35
 
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
 

--- a/gif/src/main/java/com/github/penfeizhou/animation/gif/decode/GifDecoder.java
+++ b/gif/src/main/java/com/github/penfeizhou/animation/gif/decode/GifDecoder.java
@@ -107,33 +107,20 @@ public class GifDecoder extends FrameSeqDecoder<GifReader, GifWriter> {
                 }
             }
         }
+            
+        long bufferSize = ((long) canvasWidth * canvasHeight /  ((long) sampleSize * sampleSize) + 1) * 4;
 
         try {
-            long bufferSize = ((long) canvasWidth * canvasHeight /  ((long) sampleSize * sampleSize) + 1) * 4;
-            // we need two buffers: frameBuffer & snapShot.byteBuffer
-            long totalBufferNeeded = bufferSize * 2;
-            
-            Runtime runtime = Runtime.getRuntime();
-            long freeMemory = runtime.freeMemory();
-
-            if (totalBufferNeeded > freeMemory) {
-                Log.e(TAG, String.format(
-                        "Memory status:" +
-                            "\n  Buffer needed: %.2fMB (%,d bytes)" +
-                            "\n  Free memory: %.2fMB (%,d bytes)",
-                        totalBufferNeeded / MB, totalBufferNeeded,
-                        freeMemory / MB, freeMemory
-                    )
-                );
-                throw new OutOfMemoryError("Required buffer size too large: " + totalBufferNeeded);
-            }
-
             frameBuffer = ByteBuffer.allocate((int)bufferSize);
             snapShot.byteBuffer = ByteBuffer.allocate((int)bufferSize);
         } catch (OutOfMemoryError e) {
+            Log.e(TAG, String.format(
+                    "OutOfMemoryError in GifDecoder: Buffer needed: %.2fMB (%,d bytes)",
+                    bufferSize / MB, bufferSize
+                )
+            );
             frameBuffer = null;
             snapShot.byteBuffer = null;
-            
             throw e;
         }
 

--- a/gif/src/main/java/com/github/penfeizhou/animation/gif/decode/GifDecoder.java
+++ b/gif/src/main/java/com/github/penfeizhou/animation/gif/decode/GifDecoder.java
@@ -118,12 +118,12 @@ public class GifDecoder extends FrameSeqDecoder<GifReader, GifWriter> {
 
             if (totalBufferNeeded > freeMemory) {
                 Log.e(TAG, String.format(
-                                "Memory status:" +
-                                        "\n  Buffer needed: %.2fMB (%,d bytes)" +
-                                        "\n  Free memory: %.2fMB (%,d bytes)",
-                                totalBufferNeeded / MB, totalBufferNeeded,
-                                freeMemory / MB, freeMemory
-                        )
+                        "Memory status:" +
+                            "\n  Buffer needed: %.2fMB (%,d bytes)" +
+                            "\n  Free memory: %.2fMB (%,d bytes)",
+                        totalBufferNeeded / MB, totalBufferNeeded,
+                        freeMemory / MB, freeMemory
+                    )
                 );
                 throw new OutOfMemoryError("Required buffer size too large: " + totalBufferNeeded);
             }

--- a/gif/src/main/java/com/github/penfeizhou/animation/gif/decode/GifDecoder.java
+++ b/gif/src/main/java/com/github/penfeizhou/animation/gif/decode/GifDecoder.java
@@ -6,6 +6,7 @@ import android.graphics.Color;
 import android.graphics.Paint;
 import android.graphics.PorterDuff;
 import android.graphics.Rect;
+import android.util.Log;
 
 import com.github.penfeizhou.animation.decode.Frame;
 import com.github.penfeizhou.animation.decode.FrameSeqDecoder;
@@ -24,6 +25,7 @@ import java.util.List;
  * @CreateDate: 2019-05-16
  */
 public class GifDecoder extends FrameSeqDecoder<GifReader, GifWriter> {
+    private static final String TAG = "GifDecoder";
 
     private GifWriter mGifWriter = new GifWriter();
     private final Paint paint = new Paint();
@@ -105,8 +107,36 @@ public class GifDecoder extends FrameSeqDecoder<GifReader, GifWriter> {
                 }
             }
         }
-        frameBuffer = ByteBuffer.allocate((canvasWidth * canvasHeight / (sampleSize * sampleSize) + 1) * 4);
-        snapShot.byteBuffer = ByteBuffer.allocate((canvasWidth * canvasHeight / (sampleSize * sampleSize) + 1) * 4);
+
+        try {
+            long bufferSize = ((long) canvasWidth * canvasHeight /  ((long) sampleSize * sampleSize) + 1) * 4;
+            // we need two buffers: frameBuffer & snapShot.byteBuffer
+            long totalBufferNeeded = bufferSize * 2;
+            
+            Runtime runtime = Runtime.getRuntime();
+            long freeMemory = runtime.freeMemory();
+
+            if (totalBufferNeeded > freeMemory) {
+                Log.e(TAG, String.format(
+                                "Memory status:" +
+                                        "\n  Buffer needed: %.2fMB (%,d bytes)" +
+                                        "\n  Free memory: %.2fMB (%,d bytes)",
+                                totalBufferNeeded / MB, totalBufferNeeded,
+                                freeMemory / MB, freeMemory
+                        )
+                );
+                throw new OutOfMemoryError("Required buffer size too large: " + totalBufferNeeded);
+            }
+
+            frameBuffer = ByteBuffer.allocate((int)bufferSize);
+            snapShot.byteBuffer = ByteBuffer.allocate((int)bufferSize);
+        } catch (OutOfMemoryError e) {
+            frameBuffer = null;
+            snapShot.byteBuffer = null;
+            
+            throw e;
+        }
+
         if (globalColorTable != null && bgColorIndex >= 0 && bgColorIndex < globalColorTable.getColorTable().length) {
             int abgr = globalColorTable.getColorTable()[bgColorIndex];
             this.bgColor = Color.rgb(abgr & 0xff, (abgr >> 8) & 0xff, (abgr >> 16) & 0xff);

--- a/package.json
+++ b/package.json
@@ -1,0 +1,4 @@
+{
+    "name": "APNG4Android",
+    "version": "1.0.0"
+}


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

This PR is to show the new changes that would allow the app to continue allocating buffer into memory but would catch it properly without causing a crash.  See sample:

Repo branch with reproducible crash (using Expo && expo-image):
https://github.com/rahimrahman/ExpoImageCrash/tree/crash-OutOfMemoryError

Repo branch with fix:
https://github.com/rahimrahman/ExpoImageCrash/tree/fix-crash-OutOfMemoryError

ExpoImageCrash app launch and crashes immediately:

https://github.com/user-attachments/assets/ca16c567-7a1e-45fd-ac27-0ab46a3036c2

ExpoImageCrash app no longer crashing:

https://github.com/user-attachments/assets/0763b002-d531-4a13-95a4-dcabf3d6d15f



#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

https://mattermost.atlassian.net/browse/MM-62969
